### PR TITLE
add policyreport search table definition

### DIFF
--- a/frontend/src/routes/SearchPage/__snapshots__/searchDefinitions.test.ts.snap
+++ b/frontend/src/routes/SearchPage/__snapshots__/searchDefinitions.test.ts.snap
@@ -1414,6 +1414,57 @@ Array [
 ]
 `;
 
+exports[`Correctly returns all resource definitions: SearchDefinitions-policyreport 1`] = `
+Array [
+  Object {
+    "cell": <Link
+      to={
+        Object {
+          "pathname": "/resources",
+          "search": "?cluster%3DtestCluster%26kind%3Dpod%26namespace%3DtestNamespace%26name%3DtestName",
+          "state": Object {
+            "from": "/search",
+          },
+        }
+      }
+    >
+      testName
+    </Link>,
+    "header": "Name",
+    "sort": "name",
+  },
+  Object {
+    "cell": "namespace",
+    "header": "Namespace",
+    "sort": "namespace",
+  },
+  Object {
+    "cell": "result",
+    "header": "Result",
+    "sort": "result",
+    "tooltip": "Result will be \\"error\\" if the violation is still present or \\"skip\\" if it has been remediated",
+  },
+  Object {
+    "cell": "risk",
+    "header": "Total Risk",
+    "sort": "risk",
+  },
+  Object {
+    "cell": <AcmLabels
+      collapse={Array []}
+      labels={
+        Array [
+          "testLabel=label",
+          "testLabel1=label1",
+        ]
+      }
+    />,
+    "header": "Categories",
+    "sort": "category",
+  },
+]
+`;
+
 exports[`Correctly returns all resource definitions: SearchDefinitions-release 1`] = `
 Array [
   Object {
@@ -1774,6 +1825,18 @@ Array [
     "sort": "label",
   },
 ]
+`;
+
+exports[`Correctly returns category components 1`] = `
+<AcmLabels
+  collapse={Array []}
+  labels={
+    Array [
+      "testcategory=category1",
+      "testcategory=category2",
+    ]
+  }
+/>
 `;
 
 exports[`Correctly returns empty CreateDashboardLink 1`] = `"-"`;

--- a/frontend/src/routes/SearchPage/searchDefinitions.test.ts
+++ b/frontend/src/routes/SearchPage/searchDefinitions.test.ts
@@ -169,6 +169,16 @@ test('Correctly returns label components', () => {
     expect(result).toMatchSnapshot()
 })
 
+test('Correctly returns category components', () => {
+    const item = {
+        name: 'testName',
+        namespace: 'testNamespace',
+        category: 'testcategory=category1; testcategory=category2',
+    }
+    const result = FormatLabels(item)
+    expect(result).toMatchSnapshot()
+})
+
 test('Correctly returns empty labels', () => {
     const item = {
         name: 'testName',

--- a/frontend/src/routes/SearchPage/searchDefinitions.tsx
+++ b/frontend/src/routes/SearchPage/searchDefinitions.tsx
@@ -1016,6 +1016,40 @@ const searchDefinitions: any = {
             },
         ],
     },
+    policyreport: {
+        columns: [
+            {
+                header: 'Name',
+                sort: 'name',
+                cell: (item: any) => {
+                    return CreateDetailsLink(item)
+                },
+            },
+            {
+                header: 'Namespace',
+                sort: 'namespace',
+                cell: 'namespace',
+            },
+            {
+                header: 'Result',
+                sort: 'result',
+                cell: 'result',
+                tooltip: 'Result will be "error" if the violation is still present or "skip" if it has been remediated',
+            },
+            {
+                header: 'Total Risk',
+                sort: 'risk',
+                cell: 'risk',
+            },
+            {
+                header: 'Categories',
+                sort: 'category',
+                cell: (item: any) => {
+                    return FormatLabels(item)
+                },
+            },
+        ],
+    },
     release: {
         columns: [
             {
@@ -1414,6 +1448,10 @@ export function FormatLabels(item: any) {
         const labels = item.label.split('; ')
         const labelsToHide = labels.slice(3).map((l: string) => l.split('=')[0])
         return <AcmLabels labels={labels} collapse={labelsToHide} />
+    } else if (item.category) {
+        const categories = item.category.split('; ')
+        const categoriesToHide = categories.slice(3)
+        return <AcmLabels labels={categories} collapse={categoriesToHide} />
     }
     return '-'
 }


### PR DESCRIPTION
**Related Issue:**  open-cluster-management/backlog#<ISSUE_NUMBER>

### Description of changes
- Added search table definition for PolicyReport resources, table will look like the below (Note: collector doesn't have the recent enough changes to fill all the columns with data).

![Screen Shot 2021-04-12 at 9 49 41 AM](https://user-images.githubusercontent.com/14047925/114405291-8bdd9b80-9b74-11eb-909c-6412b0652cd3.png)


