### PR TITLE
Update Insight search table column definitions

### DIFF
--- a/frontend/src/routes/SearchPage/__snapshots__/searchDefinitions.test.ts.snap
+++ b/frontend/src/routes/SearchPage/__snapshots__/searchDefinitions.test.ts.snap
@@ -1426,28 +1426,19 @@ Array [
     "sort": "namespace",
   },
   Object {
-    "cell": "result",
-    "header": "Result",
-    "sort": "result",
-    "tooltip": "Result will be \\"error\\" if the violation is still present or \\"skip\\" if it has been remediated",
+    "cell": "numInsightPolicies",
+    "header": "Total insight policies",
+    "sort": "numInsightPolicies",
+    "tooltip": "This field is indexed as numInsightPolicies. If you would like to filter PolicyReports by number of violations please use: numInsightPolicies > x",
   },
   Object {
-    "cell": "risk",
-    "header": "Total Risk",
-    "sort": "risk",
+    "cell": "-",
+    "header": "Insight policies",
+    "tooltip": "This field is indexed as insightPolicies. If you would like to filter PolicyReports containing specific policies please use: insightPolicies:<policyName>",
   },
   Object {
-    "cell": <AcmLabels
-      collapse={Array []}
-      labels={
-        Array [
-          "testLabel=label",
-          "testLabel1=label1",
-        ]
-      }
-    />,
+    "cell": "-",
     "header": "Categories",
-    "sort": "category",
   },
 ]
 `;

--- a/frontend/src/routes/SearchPage/__snapshots__/searchDefinitions.test.ts.snap
+++ b/frontend/src/routes/SearchPage/__snapshots__/searchDefinitions.test.ts.snap
@@ -1428,7 +1428,8 @@ Array [
   Object {
     "cell": "-",
     "header": "Insight policy violations",
-    "tooltip": "Total number of insight policies violated by the cluster. To view clusters based on number of violations, search for numInsightPolicies. To search for PolicyReports that contain specific policies, search for insightPolicies",
+    "tooltip": "Total number of insight policies violated by the cluster. To view clusters based on number of violations,
+                     search for numInsightPolicies. To search for PolicyReports that contain specific policies, search for insightPolicies.",
   },
   Object {
     "cell": "-",

--- a/frontend/src/routes/SearchPage/__snapshots__/searchDefinitions.test.ts.snap
+++ b/frontend/src/routes/SearchPage/__snapshots__/searchDefinitions.test.ts.snap
@@ -1426,15 +1426,9 @@ Array [
     "sort": "namespace",
   },
   Object {
-    "cell": "numInsightPolicies",
-    "header": "Total insight policies",
-    "sort": "numInsightPolicies",
-    "tooltip": "This field is indexed as numInsightPolicies. If you would like to filter PolicyReports by number of violations please use: numInsightPolicies > x",
-  },
-  Object {
     "cell": "-",
-    "header": "Insight policies",
-    "tooltip": "This field is indexed as insightPolicies. If you would like to filter PolicyReports containing specific policies please use: insightPolicies:<policyName>",
+    "header": "Insight policy violations",
+    "tooltip": "Total number of insight policies violated by the cluster. To view clusters based on number of violations, search for numInsightPolicies. To search for PolicyReports that contain specific policies, search for insightPolicies",
   },
   Object {
     "cell": "-",
@@ -1828,6 +1822,78 @@ exports[`Correctly returns formatSearchbarSuggestions no timestamp 1`] = `"-"`;
 exports[`Correctly returns formatSearchbarSuggestions with T in timestamp 1`] = `"3 days ago"`;
 
 exports[`Correctly returns formatSearchbarSuggestions without T in timestamp 1`] = `"3 days ago"`;
+
+exports[`Correctly returns insight policies 1`] = `
+<LabelGroup
+  aria-label="Label group category"
+  categoryName=""
+  closeBtnAriaLabel="Close label group"
+  collapsedText="3 more"
+  defaultIsOpen={false}
+  expandedText="Show less"
+  isClosable={false}
+  isVertical={false}
+  numLabels={2}
+  onClick={[Function]}
+  tooltipPosition="top"
+>
+  <Label
+    render={[Function]}
+    style={
+      Object {
+        "backgroundColor": "#fff",
+        "padding": "0 .25rem 0 0",
+      }
+    }
+  >
+    AUTH_OPERATOR_PROXY_ERROR
+  </Label>
+  <Label
+    render={[Function]}
+    style={
+      Object {
+        "backgroundColor": "#fff",
+        "padding": "0 .25rem 0 0",
+      }
+    }
+  >
+    CONTAINER_ROOT_PARTITION_SIZE
+  </Label>
+  <Label
+    render={[Function]}
+    style={
+      Object {
+        "backgroundColor": "#fff",
+        "padding": "0 .25rem 0 0",
+      }
+    }
+  >
+    MASTER_DEFINED_AS_MACHINESETS
+  </Label>
+  <Label
+    render={[Function]}
+    style={
+      Object {
+        "backgroundColor": "#fff",
+        "padding": "0 .25rem 0 0",
+      }
+    }
+  >
+    NODES_MINIMUM_REQUIREMENTS_NOT_MET
+  </Label>
+  <Label
+    render={[Function]}
+    style={
+      Object {
+        "backgroundColor": "#fff",
+        "padding": "0 .25rem 0 0",
+      }
+    }
+  >
+    UNSUPPORT_SDN_PLUGIN
+  </Label>
+</LabelGroup>
+`;
 
 exports[`Correctly returns label components 1`] = `
 <AcmLabels

--- a/frontend/src/routes/SearchPage/searchDefinitions.test.ts
+++ b/frontend/src/routes/SearchPage/searchDefinitions.test.ts
@@ -6,6 +6,7 @@ import searchDefinitions, {
     CreateApplicationLink,
     CreateExternalLink,
     FormatLabels,
+    FormatInsightData,
     GetUrlSearchParam,
 } from './searchDefinitions'
 
@@ -175,7 +176,7 @@ test('Correctly returns category components', () => {
         namespace: 'testNamespace',
         category: 'testcategory=category1; testcategory=category2',
     }
-    const result = FormatLabels(item)
+    const result = FormatInsightData(item.category)
     expect(result).toMatchSnapshot()
 })
 

--- a/frontend/src/routes/SearchPage/searchDefinitions.test.ts
+++ b/frontend/src/routes/SearchPage/searchDefinitions.test.ts
@@ -6,7 +6,8 @@ import searchDefinitions, {
     CreateApplicationLink,
     CreateExternalLink,
     FormatLabels,
-    FormatInsightData,
+    FormatInsightPolicies,
+    FormatInsightCategories,
     GetUrlSearchParam,
 } from './searchDefinitions'
 
@@ -170,13 +171,25 @@ test('Correctly returns label components', () => {
     expect(result).toMatchSnapshot()
 })
 
+test('Correctly returns insight policies', () => {
+    const item = {
+        name: 'testName',
+        namespace: 'testNamespace',
+        insightPolicies:
+            'AUTH_OPERATOR_PROXY_ERROR; CONTAINER_ROOT_PARTITION_SIZE; MASTER_DEFINED_AS_MACHINESETS; NODES_MINIMUM_REQUIREMENTS_NOT_MET; UNSUPPORT_SDN_PLUGIN',
+        category: 'testcategory=category1; testcategory=category2',
+    }
+    const result = FormatInsightPolicies(item)
+    expect(result).toMatchSnapshot()
+})
+
 test('Correctly returns category components', () => {
     const item = {
         name: 'testName',
         namespace: 'testNamespace',
         category: 'testcategory=category1; testcategory=category2',
     }
-    const result = FormatInsightData(item.category)
+    const result = FormatInsightCategories(item.category)
     expect(result).toMatchSnapshot()
 })
 

--- a/frontend/src/routes/SearchPage/searchDefinitions.tsx
+++ b/frontend/src/routes/SearchPage/searchDefinitions.tsx
@@ -1037,7 +1037,8 @@ const searchDefinitions: any = {
                     return FormatInsightPolicies(item)
                 },
                 tooltip:
-                    'Total number of insight policies violated by the cluster. To view clusters based on number of violations, search for numInsightPolicies. To search for PolicyReports that contain specific policies, search for insightPolicies',
+                    `Total number of insight policies violated by the cluster. To view clusters based on number of violations,
+                     search for numInsightPolicies. To search for PolicyReports that contain specific policies, search for insightPolicies.`,
             },
             {
                 header: 'Categories',

--- a/frontend/src/routes/SearchPage/searchDefinitions.tsx
+++ b/frontend/src/routes/SearchPage/searchDefinitions.tsx
@@ -1036,8 +1036,7 @@ const searchDefinitions: any = {
                 cell: (item: any) => {
                     return FormatInsightPolicies(item)
                 },
-                tooltip:
-                    `Total number of insight policies violated by the cluster. To view clusters based on number of violations,
+                tooltip: `Total number of insight policies violated by the cluster. To view clusters based on number of violations,
                      search for numInsightPolicies. To search for PolicyReports that contain specific policies, search for insightPolicies.`,
             },
             {

--- a/frontend/src/routes/SearchPage/searchDefinitions.tsx
+++ b/frontend/src/routes/SearchPage/searchDefinitions.tsx
@@ -1467,4 +1467,3 @@ export function FormatInsightData(data: string) {
 }
 
 export default searchDefinitions
-

--- a/frontend/src/routes/SearchPage/searchDefinitions.tsx
+++ b/frontend/src/routes/SearchPage/searchDefinitions.tsx
@@ -1031,21 +1031,24 @@ const searchDefinitions: any = {
                 cell: 'namespace',
             },
             {
-                header: 'Result',
-                sort: 'result',
-                cell: 'result',
-                tooltip: 'Result will be "error" if the violation is still present or "skip" if it has been remediated',
+                header: 'Total insight policies',
+                sort: 'numInsightPolicies',
+                cell: 'numInsightPolicies',
+                tooltip:
+                    'This field is indexed as numInsightPolicies. If you would like to filter PolicyReports by number of violations please use: numInsightPolicies > x',
             },
             {
-                header: 'Total Risk',
-                sort: 'risk',
-                cell: 'risk',
+                header: 'Insight policies',
+                cell: (item: any) => {
+                    return FormatInsightData(item.insightPolicies)
+                },
+                tooltip:
+                    'This field is indexed as insightPolicies. If you would like to filter PolicyReports containing specific policies please use: insightPolicies:<policyName>',
             },
             {
                 header: 'Categories',
-                sort: 'category',
                 cell: (item: any) => {
-                    return FormatLabels(item)
+                    return FormatInsightData(item.category)
                 },
             },
         ],
@@ -1450,12 +1453,18 @@ export function FormatLabels(item: any) {
         const labels = item.label.split('; ')
         const labelsToHide = labels.slice(3).map((l: string) => l.split('=')[0])
         return <AcmLabels labels={labels} collapse={labelsToHide} />
-    } else if (item.category) {
-        const categories = item.category.split('; ')
-        const categoriesToHide = categories.slice(3)
-        return <AcmLabels labels={categories} collapse={categoriesToHide} />
+    }
+    return '-'
+}
+
+export function FormatInsightData(data: string) {
+    if (data) {
+        const dataArray = data.split('; ')
+        const dataToHide = dataArray.slice(3)
+        return <AcmLabels labels={dataArray} collapse={dataToHide} />
     }
     return '-'
 }
 
 export default searchDefinitions
+

--- a/frontend/src/routes/SearchPage/searchDefinitions.tsx
+++ b/frontend/src/routes/SearchPage/searchDefinitions.tsx
@@ -1,7 +1,8 @@
 // Copyright (c) 2021 Red Hat, Inc.
 // Copyright Contributors to the Open Cluster Management project
+
 import _ from 'lodash'
-import React from 'react'
+import { Label, LabelGroup } from '@patternfly/react-core'
 import { Link } from 'react-router-dom'
 import moment from 'moment'
 import { AcmLabels } from '@open-cluster-management/ui-components'
@@ -1031,24 +1032,17 @@ const searchDefinitions: any = {
                 cell: 'namespace',
             },
             {
-                header: 'Total insight policies',
-                sort: 'numInsightPolicies',
-                cell: 'numInsightPolicies',
-                tooltip:
-                    'This field is indexed as numInsightPolicies. If you would like to filter PolicyReports by number of violations please use: numInsightPolicies > x',
-            },
-            {
-                header: 'Insight policies',
+                header: 'Insight policy violations',
                 cell: (item: any) => {
-                    return FormatInsightData(item.insightPolicies)
+                    return FormatInsightPolicies(item)
                 },
                 tooltip:
-                    'This field is indexed as insightPolicies. If you would like to filter PolicyReports containing specific policies please use: insightPolicies:<policyName>',
+                    'Total number of insight policies violated by the cluster. To view clusters based on number of violations, search for numInsightPolicies. To search for PolicyReports that contain specific policies, search for insightPolicies',
             },
             {
                 header: 'Categories',
                 cell: (item: any) => {
-                    return FormatInsightData(item.category)
+                    return FormatInsightCategories(item.category)
                 },
             },
         ],
@@ -1457,7 +1451,35 @@ export function FormatLabels(item: any) {
     return '-'
 }
 
-export function FormatInsightData(data: string) {
+export function FormatInsightPolicies(item: any) {
+    if (item.insightPolicies) {
+        const policyArray = item.insightPolicies.split('; ')
+        const policiesToHide = policyArray.slice(2)
+        return (
+            <LabelGroup collapsedText={`${policiesToHide.length} more`} expandedText={'Show less'} numLabels={2}>
+                {policyArray.map((policy: any, index: number) => {
+                    return (
+                        <Label
+                            style={{ backgroundColor: '#fff', padding: '0 .25rem 0 0' }}
+                            key={policy}
+                            render={({ content }) => (
+                                <span>
+                                    {content}
+                                    {index < policyArray.length - 1 && ', '}
+                                </span>
+                            )}
+                        >
+                            {policy}
+                        </Label>
+                    )
+                })}
+            </LabelGroup>
+        )
+    }
+    return '-'
+}
+
+export function FormatInsightCategories(data: string) {
     if (data) {
         const dataArray = data.split('; ')
         const dataToHide = dataArray.slice(3)


### PR DESCRIPTION
**Related Issue:**  open-cluster-management/backlog#11701

### Description of changes
- Updated the table column definitions for Insight resources to look like:
![Screen Shot 2021-04-28 at 2 26 02 PM](https://user-images.githubusercontent.com/14047925/116461636-80f25e80-a836-11eb-8604-f56c850bf2b2.png)

/hold
