### PR TITLE
Added alert condition for search disablement

### DIFF
--- a/frontend/public/locales/en/overview.json
+++ b/frontend/public/locales/en/overview.json
@@ -3,6 +3,7 @@
     "overview.add.provider": "Add provider connection",
     "overview.data.error.message": "The backend service is unavailable.",
     "overview.data.error.title": "An unexpected error occurred.",
+    "overview.data.info.title": "Configuration alert",
     "overview.donut.compliance.description": "Overview of {{compliance}} status",
     "overview.donut.pod.description": "Overview of {{pod}} count and status",
     "overview.donut.status.description": "Overview of {{cluster}} status",

--- a/frontend/public/locales/en/search.json
+++ b/frontend/public/locales/en/search.json
@@ -2,7 +2,7 @@
     "search": "Search",
     "search.filter.errors.description": "The search service is unavailable.",
     "search.filter.errors.title": "An unexpected error occurred.",
-    "search.filter.info.title": "Please read the comment below.",
+    "search.filter.info.title": "Configuration alert",
     "search.modal.delete.resource.action.cancel": "Cancel",
     "search.modal.delete.resource.action.delete": "Delete",
     "search.modal.delete.resource.text": "Removing {{resourceName}} is irreversible. Are you sure that you want to continue?",

--- a/frontend/public/locales/en/search.json
+++ b/frontend/public/locales/en/search.json
@@ -2,6 +2,7 @@
     "search": "Search",
     "search.filter.errors.description": "The search service is unavailable.",
     "search.filter.errors.title": "An unexpected error occurred.",
+    "search.filter.info.title": "Please read the comment below.",
     "search.modal.delete.resource.action.cancel": "Cancel",
     "search.modal.delete.resource.action.delete": "Delete",
     "search.modal.delete.resource.text": "Removing {{resourceName}} is irreversible. Are you sure that you want to continue?",

--- a/frontend/src/routes/Overview/OverviewPage.tsx
+++ b/frontend/src/routes/Overview/OverviewPage.tsx
@@ -413,7 +413,7 @@ export default function OverviewPage() {
                     <AcmAlert
                         noClose
                         isInline
-                        variant={'danger'}
+                        variant={searchError?.graphQLErrors[0]?.message.includes('not enabled') ? 'info' : 'danger'}
                         title={t('overview.data.error.title')}
                         subtitle={searchError?.graphQLErrors[0]?.message || t('overview.data.error.message')}
                     />

--- a/frontend/src/routes/Overview/OverviewPage.tsx
+++ b/frontend/src/routes/Overview/OverviewPage.tsx
@@ -414,7 +414,11 @@ export default function OverviewPage() {
                         noClose
                         isInline
                         variant={searchError?.graphQLErrors[0]?.message.includes('not enabled') ? 'info' : 'danger'}
-                        title={t('overview.data.error.title')}
+                        title={
+                            searchError?.graphQLErrors[0]?.message.includes('not enabled')
+                                ? t('overview.data.info.title')
+                                : t('overview.data.error.title')
+                        }
                         subtitle={searchError?.graphQLErrors[0]?.message || t('overview.data.error.message')}
                     />
                 </PageSection>

--- a/frontend/src/routes/SearchPage/SearchPage.tsx
+++ b/frontend/src/routes/SearchPage/SearchPage.tsx
@@ -59,9 +59,17 @@ function HandleErrors(schemaError: ApolloError | undefined, completeError: Apoll
             <div style={{ marginBottom: '1rem' }}>
                 <AcmAlert
                     noClose
-                    variant={'danger'}
+                    variant={
+                        schemaError?.message.includes('not enabled') || completeError?.message.includes('not enabled')
+                            ? 'info'
+                            : 'danger'
+                    }
                     isInline
-                    title={t('search.filter.errors.title')}
+                    title={
+                        schemaError?.message.includes('not enabled') || completeError?.message.includes('not enabled')
+                            ? t('search.filter.info.title')
+                            : t('search.filter.errors.title')
+                    }
                     subtitle={schemaError?.message || completeError?.message}
                 />
             </div>


### PR DESCRIPTION
**Related Issue:**  open-cluster-management/backlog#12607

### Description of changes
- Added conditional statement for search alert to support info message when search is not configured within the cluster. If the message does not contain `not enabled`, then the error message will be displayed instead.

#### Before conditional statement
![image](https://user-images.githubusercontent.com/28898909/118701800-23708280-b7e2-11eb-9993-1e3a3daead21.png)

---

#### After conditional statement
![Screen Shot 2021-05-18 at 2 06 34 PM](https://user-images.githubusercontent.com/28898909/118701925-4733c880-b7e2-11eb-8786-859f6dcdfc80.png)