### PR TITLE
removed cancel action from help modal

### DIFF
--- a/frontend/src/routes/SearchPage/components/Modals/SearchInfoModal.tsx
+++ b/frontend/src/routes/SearchPage/components/Modals/SearchInfoModal.tsx
@@ -54,11 +54,6 @@ export const SearchInfoModal = (props: any) => {
                 width={'50%'}
                 onClose={props.onClose}
                 isOpen={props.isOpen}
-                actions={[
-                    <AcmButton key="close" variant={ButtonVariant.primary} onClick={props.onClose}>
-                        {t('search.modal.info.action.cancel')}
-                    </AcmButton>,
-                ]}
             >
                 <div>
                     <h2>{t('search.modal.info.subtitle')}</h2>


### PR DESCRIPTION
**Related Issue:**  open-cluster-management/backlog#12351

### Description of changes
- Removed `cancel` button from help modal to remain consistent with Welcome page.

![Screen Shot 2021-05-19 at 1 30 57 PM](https://user-images.githubusercontent.com/28898909/118859570-6137de80-b8a8-11eb-9be8-7fc27ccddeff.png)
