### PR TITLE
Show scope in PolicyReport results table

### DIFF
--- a/frontend/src/routes/SearchPage/__snapshots__/searchDefinitions.test.ts.snap
+++ b/frontend/src/routes/SearchPage/__snapshots__/searchDefinitions.test.ts.snap
@@ -1424,7 +1424,7 @@ Array [
     "cell": "scope",
     "header": "Scope",
     "sort": "scope",
-    "tooltip": "Scope refers to the cluster that is affected by the PolicyReport.",
+    "tooltip": "Scope refers to the cluster associated to the PolicyReport.",
   },
   Object {
     "cell": "-",

--- a/frontend/src/routes/SearchPage/__snapshots__/searchDefinitions.test.ts.snap
+++ b/frontend/src/routes/SearchPage/__snapshots__/searchDefinitions.test.ts.snap
@@ -1421,9 +1421,10 @@ Array [
     "sort": "name",
   },
   Object {
-    "cell": "namespace",
-    "header": "Namespace",
-    "sort": "namespace",
+    "cell": "scope",
+    "header": "Scope",
+    "sort": "scope",
+    "tooltip": "Represents the cluster each PolicyReport is scoped to.",
   },
   Object {
     "cell": "-",

--- a/frontend/src/routes/SearchPage/__snapshots__/searchDefinitions.test.ts.snap
+++ b/frontend/src/routes/SearchPage/__snapshots__/searchDefinitions.test.ts.snap
@@ -1424,7 +1424,7 @@ Array [
     "cell": "scope",
     "header": "Scope",
     "sort": "scope",
-    "tooltip": "Represents the cluster each PolicyReport is scoped to.",
+    "tooltip": "Scope refers to the cluster that is affected by the PolicyReport.",
   },
   Object {
     "cell": "-",

--- a/frontend/src/routes/SearchPage/searchDefinitions.tsx
+++ b/frontend/src/routes/SearchPage/searchDefinitions.tsx
@@ -1030,7 +1030,7 @@ const searchDefinitions: any = {
                 header: 'Scope',
                 sort: 'scope',
                 cell: 'scope',
-                tooltip: 'Represents the cluster each PolicyReport is scoped to.',
+                tooltip: 'Scope refers to the cluster that is affected by the PolicyReport.',
             },
             {
                 header: 'Insight policy violations',

--- a/frontend/src/routes/SearchPage/searchDefinitions.tsx
+++ b/frontend/src/routes/SearchPage/searchDefinitions.tsx
@@ -1030,7 +1030,7 @@ const searchDefinitions: any = {
                 header: 'Scope',
                 sort: 'scope',
                 cell: 'scope',
-                tooltip: 'Scope refers to the cluster that is affected by the PolicyReport.',
+                tooltip: 'Scope refers to the cluster associated to the PolicyReport.',
             },
             {
                 header: 'Insight policy violations',

--- a/frontend/src/routes/SearchPage/searchDefinitions.tsx
+++ b/frontend/src/routes/SearchPage/searchDefinitions.tsx
@@ -1027,9 +1027,10 @@ const searchDefinitions: any = {
                 },
             },
             {
-                header: 'Namespace',
-                sort: 'namespace',
-                cell: 'namespace',
+                header: 'Scope',
+                sort: 'scope',
+                cell: 'scope',
+                tooltip: 'Represents the cluster each PolicyReport is scoped to.',
             },
             {
                 header: 'Insight policy violations',


### PR DESCRIPTION
Signed-off-by: Zack Layne <zlayne@redhat.com>

**Related Issue:**  https://github.com/open-cluster-management/backlog/issues/12669

### Description of changes
- Show cluster scope in PolicyReport results table

