### PR TITLE
Consistent errors on YAML page

### DIFF
--- a/frontend/src/routes/DetailsPage/YAMLPage.tsx
+++ b/frontend/src/routes/DetailsPage/YAMLPage.tsx
@@ -131,7 +131,7 @@ export default function YAMLPage(props: {
                 />
             </PageSection>
         )
-    } else if (resource?.getResource.message ?? (resource?.getResource[0] && resource?.getResource[0].message)) {
+    } else if (resource?.getResource?.message ?? (resource?.getResource[0] && resource?.getResource[0].message)) {
         return (
             <PageSection>
                 <AcmAlert
@@ -140,7 +140,7 @@ export default function YAMLPage(props: {
                     isInline={true}
                     title={`${t('yaml.getresource.error')} ${name}`}
                     subtitle={
-                        resource?.getResource.message ?? (resource?.getResource[0] && resource?.getResource[0].message)
+                        resource?.getResource?.message ?? (resource?.getResource[0] && resource?.getResource[0].message)
                     }
                 />
             </PageSection>

--- a/frontend/src/routes/DetailsPage/YAMLPage.tsx
+++ b/frontend/src/routes/DetailsPage/YAMLPage.tsx
@@ -131,7 +131,7 @@ export default function YAMLPage(props: {
                 />
             </PageSection>
         )
-    } else if (resource?.getResource?.message) {
+    } else if (resource?.getResource.message ?? (resource?.getResource[0] && resource?.getResource[0].message)) {
         return (
             <PageSection>
                 <AcmAlert
@@ -139,7 +139,9 @@ export default function YAMLPage(props: {
                     variant={'danger'}
                     isInline={true}
                     title={`${t('yaml.getresource.error')} ${name}`}
-                    subtitle={resource?.getResource?.message}
+                    subtitle={
+                        resource?.getResource.message ?? (resource?.getResource[0] && resource?.getResource[0].message)
+                    }
                 />
             </PageSection>
         )


### PR DESCRIPTION
Signed-off-by: Zack Layne <zlayne@redhat.com>

**Related Issue:**  open-cluster-management/backlog#10759

### Description of changes
- Keep error messages consistent for local and managed resource errors.

New errors...
Local:
![Screen Shot 2021-06-07 at 11 06 53 AM](https://user-images.githubusercontent.com/14047925/121053491-6db5a580-c789-11eb-83ca-415b4083145b.png)

Managed:
![Screen Shot 2021-06-07 at 11 06 28 AM](https://user-images.githubusercontent.com/14047925/121053507-71e1c300-c789-11eb-857c-7d645b9a18d7.png)


