### PR TITLE
ui-components 0.179.0

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2938,9 +2938,9 @@
             }
         },
         "@open-cluster-management/ui-components": {
-            "version": "0.178.0",
-            "resolved": "https://registry.npmjs.org/@open-cluster-management/ui-components/-/ui-components-0.178.0.tgz",
-            "integrity": "sha512-aYFUVFM4WYZeF6eYoiudlaGVX1qGYm/aEMg9VVR4s8QTKj+GtAkc8s3oanURuV04D5Tr2RpQa8x2mE2Mi9fqdQ==",
+            "version": "0.179.0",
+            "resolved": "https://registry.npmjs.org/@open-cluster-management/ui-components/-/ui-components-0.179.0.tgz",
+            "integrity": "sha512-SR81EpGvaGU4b5LTsRoM9W/nYJR3iiizIaO68v8uSnULY6KEWHblDFMocMAFA+91ngH/d8NiQU9Qu6j7Kavf7Q==",
             "requires": {
                 "@material-ui/core": "^4.11.4",
                 "@material-ui/styles": "^4.11.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,7 +21,7 @@
     },
     "dependencies": {
         "@apollo/client": "^3.3.20",
-        "@open-cluster-management/ui-components": "^0.178.0",
+        "@open-cluster-management/ui-components": "^0.179.0",
         "@patternfly/react-core": "^4.128.2",
         "@types/node": "^15.12.4",
         "@types/react": "^17.0.11",


### PR DESCRIPTION
**Related Issue:**  https://github.com/open-cluster-management/backlog/issues/12617

### Description of changes
- Updated ui-components to 0.179.0 so that perspective switcher is not displayed on OCP 4.6

