### PR TITLE
added stale pr workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,22 @@
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+    - cron: '0 8 * * Mon-Fri'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/stale@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          close-pr-message: '@${{ github.event.pull_request.user.login }} Closing pr due to lack of activity.'
+          days-before-pr-stale: 7
+          days-before-pr-close: 14
+          stale-pr-message: "@${{ github.event.pull_request.user.login }} This pr has been automatically marked as stale because it has not had recent activity. It will be closed in 14 days (2 weeks), if no further activity occurs. @${{ join(github.event.pull_request.requested_reviewers.*.login, ' @') }} please help to get the pr reviewed."
+          stale-pr-label: 'stale'


### PR DESCRIPTION
Signed-off-by: dislbenn <lavontae.bennett@gmail.com>

### Description of changes
- Added stale GitHub action. This will allow GitHub to mark pr/issues as stale if they haven't received activity over a certain period of time.
