### PR TITLE
[release-2.3] Fix vSphere clusters in overview

### DIFF
--- a/frontend/src/routes/Overview/OverviewPage.test.tsx
+++ b/frontend/src/routes/Overview/OverviewPage.test.tsx
@@ -22,6 +22,8 @@ it('should responsed with correct value for mapProviderFromLabel function', () =
     expect(mapProviderFromLabel('IBMZPlatform')).toEqual('ibmz')
     expect(mapProviderFromLabel('RedHat')).toEqual('rhocm')
     expect(mapProviderFromLabel('VMware')).toEqual('vmw')
+    expect(mapProviderFromLabel('VSphere')).toEqual('vmw')
+    expect(mapProviderFromLabel('vSphere')).toEqual('vmw')
     expect(mapProviderFromLabel('other')).toEqual('other')
 })
 

--- a/frontend/src/routes/Overview/OverviewPage.tsx
+++ b/frontend/src/routes/Overview/OverviewPage.tsx
@@ -368,11 +368,11 @@ export default function OverviewPage() {
     }
 
     const { kubernetesTypes, regions, ready, offline, providers } = summaryData
-
     const cloudLabelFilter: string = selectedCloud === '' ? '' : `%20label%3acloud=${selectedCloud}`
-    function buildSummaryLinks(kind: string) {
+    function buildSummaryLinks(kind: string, localCluster?: boolean) {
+        const localClusterFilter: string = localCluster === true ? `%20cluster%3Alocal-cluster` : ''
         return selectedCloud === ''
-            ? `/search?filters={"textsearch":"kind%3A${kind}"}`
+            ? `/search?filters={"textsearch":"kind%3A${kind}${localClusterFilter}"}`
             : `/search?filters={"textsearch":"kind%3Acluster${cloudLabelFilter}"}&showrelated=${kind}`
     }
     const summary =
@@ -383,7 +383,7 @@ export default function OverviewPage() {
                       isPrimary: false,
                       description: 'Applications',
                       count: data?.overview?.applications?.length || 0,
-                      href: buildSummaryLinks('application'),
+                      href: buildSummaryLinks('application', true),
                   },
                   {
                       isPrimary: false,

--- a/frontend/src/routes/Overview/OverviewPage.tsx
+++ b/frontend/src/routes/Overview/OverviewPage.tsx
@@ -379,9 +379,12 @@ export default function OverviewPage() {
 
     const { kubernetesTypes, regions, ready, offline, providers } = summaryData
     const provider = providers.find((p: any) => p.provider === selectedCloud)
-    const cloudLabelFilter: string = selectedCloud === ''
-        ? ''
-        : `%20label%3a${Array.from(provider.cloudLabels).map(n => `cloud=${n}`).join(',')}`
+    const cloudLabelFilter: string =
+        selectedCloud === ''
+            ? ''
+            : `%20label%3a${Array.from(provider.cloudLabels)
+                  .map((n) => `cloud=${n}`)
+                  .join(',')}`
     function buildSummaryLinks(kind: string, localCluster?: boolean) {
         const localClusterFilter: string = localCluster === true ? `%20cluster%3Alocal-cluster` : ''
         return selectedCloud === ''


### PR DESCRIPTION
**Related Issue:**  open-cluster-management/backlog#16135
https://bugzilla.redhat.com/show_bug.cgi?id=2004188

### Description of changes
- VMware / vSphere show as VMware vSphere on the Overview regardless of case
- Grouping is fixed so different labels can coexist (for example, different cases, miscellaneous "Other" labels)
- Search for all labels in the group (eg. `search?filters={"textsearch":"kind%3Acluster%20label%3Acloud%3DVSphere%2Ccloud%3DvSphere%2Ccloud%3DVMware"`}... this does not work for the Other category which includes unlabelled clusters - we still get only `cloud=Other` clusters in that case)

