### PR TITLE
Fix vSphere clusters in overview

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -3656,35 +3656,66 @@
             }
         },
         "@open-cluster-management/ui-components": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/@open-cluster-management/ui-components/-/ui-components-1.4.0.tgz",
-            "integrity": "sha512-yvPK4E8PAQ7y7WSVRqVUTVI5cACo5RC5JcgaAumCzlGGp3SlcF/+3s+CoFyrVut7rmjggk4SZ0S/rFu2XnWBSw==",
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/@open-cluster-management/ui-components/-/ui-components-1.9.0.tgz",
+            "integrity": "sha512-t5pZJ023WaPidKcV+Mbt9x90BhRN5p8pxRozu1XUqDRTS+vwe81Djo/Z+eN4B+3h87LmDRlRu7oDKMyjM5EPlQ==",
             "requires": {
-                "@material-ui/core": "^4.11.4",
+                "@material-ui/core": "^4.12.3",
                 "@material-ui/styles": "^4.11.4",
-                "@patternfly/react-charts": "^6.15.3",
-                "@patternfly/react-core": "^4.135.0",
-                "@patternfly/react-table": "^4.29.0",
-                "@react-hook/resize-observer": "^1.2.2",
+                "@patternfly/react-charts": "^6.15.20",
+                "@patternfly/react-core": "^4.152.4",
+                "@patternfly/react-table": "^4.29.58",
+                "@react-hook/resize-observer": "^1.2.4",
                 "fuse.js": "^6.4.6",
                 "get-value": "^3.0.1",
                 "isomorphic-fetch": "^3.0.0",
                 "moment": "^2.29.1",
-                "nock": "^13.1.0",
-                "react-router-dom": "^5.2.0",
+                "nock": "^13.1.3",
+                "react-router-dom": "^5.3.0",
                 "react-tag-autocomplete": "6.1.0"
+            },
+            "dependencies": {
+                "@patternfly/react-core": {
+                    "version": "4.152.4",
+                    "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-4.152.4.tgz",
+                    "integrity": "sha512-saMnAoF3KnYB5k6K04Y6NtO61bXYl71yzGPYSrM/DjyWDlIGLqPPhMe4kbWafLTpSgJdkxPoODgVMDp2ZIJ0Jw==",
+                    "requires": {
+                        "@patternfly/react-icons": "^4.11.14",
+                        "@patternfly/react-styles": "^4.11.13",
+                        "@patternfly/react-tokens": "^4.12.15",
+                        "focus-trap": "6.2.2",
+                        "react-dropzone": "9.0.0",
+                        "tippy.js": "5.1.2",
+                        "tslib": "^2.0.0"
+                    }
+                },
+                "@patternfly/react-icons": {
+                    "version": "4.11.14",
+                    "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-4.11.14.tgz",
+                    "integrity": "sha512-SBwID1p+UaQ9BSmzIRFr+BJEhYgx1rWHlm2HIZzhoz7BG3Q7byaQ8ZNfZLm0D+ZGVJQ+fq0zUHGE1nzxDPFqNQ=="
+                },
+                "@patternfly/react-styles": {
+                    "version": "4.11.13",
+                    "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-4.11.13.tgz",
+                    "integrity": "sha512-svhnWIqZwJt1cOxwYjvz6lVYeL+c9D17xpKqlkJapXRxJL3ppTfIqwBrT3o9+02ElaXUTKt4xjMkSnEVjw4qxA=="
+                },
+                "@patternfly/react-tokens": {
+                    "version": "4.12.15",
+                    "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-4.12.15.tgz",
+                    "integrity": "sha512-lRW0qxGjuFEPMweBSQFHNRNoxavx5uR8b28f0lPN0Jlz4QsaCFVTmHM2XqflOHDpjE8SPJW/hJMSsyUrqnM5dw=="
+                }
             }
         },
         "@patternfly/react-charts": {
-            "version": "6.15.14",
-            "resolved": "https://registry.npmjs.org/@patternfly/react-charts/-/react-charts-6.15.14.tgz",
-            "integrity": "sha512-bwAnqK1QxxWQaXnwlTgRCk/QqrMq1Z5C5iqeVgX0FWyVM5YtBJRwvh9JOEhKQW9B7ed4ttxOhI4spMPOP14+tg==",
+            "version": "6.15.20",
+            "resolved": "https://registry.npmjs.org/@patternfly/react-charts/-/react-charts-6.15.20.tgz",
+            "integrity": "sha512-aoHrANVAirdMs42rCSZuu2X+Sfa7jtePeoaN23p3ige3PitN4fbTsSCzu0o1jfdVKa8q56PHxxLtWa+rIWZieA==",
             "requires": {
-                "@patternfly/react-styles": "^4.11.8",
-                "@patternfly/react-tokens": "^4.12.9",
+                "@patternfly/react-styles": "^4.11.13",
+                "@patternfly/react-tokens": "^4.12.15",
                 "hoist-non-react-statics": "^3.3.0",
                 "lodash": "^4.17.19",
-                "tslib": "1.13.0",
+                "tslib": "^2.0.0",
                 "victory-area": "^35.9.0",
                 "victory-axis": "^35.9.0",
                 "victory-bar": "^35.9.0",
@@ -3702,10 +3733,15 @@
                 "victory-zoom-container": "^35.9.0"
             },
             "dependencies": {
-                "tslib": {
-                    "version": "1.13.0",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-                    "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+                "@patternfly/react-styles": {
+                    "version": "4.11.13",
+                    "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-4.11.13.tgz",
+                    "integrity": "sha512-svhnWIqZwJt1cOxwYjvz6lVYeL+c9D17xpKqlkJapXRxJL3ppTfIqwBrT3o9+02ElaXUTKt4xjMkSnEVjw4qxA=="
+                },
+                "@patternfly/react-tokens": {
+                    "version": "4.12.15",
+                    "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-4.12.15.tgz",
+                    "integrity": "sha512-lRW0qxGjuFEPMweBSQFHNRNoxavx5uR8b28f0lPN0Jlz4QsaCFVTmHM2XqflOHDpjE8SPJW/hJMSsyUrqnM5dw=="
                 }
             }
         },
@@ -3741,22 +3777,46 @@
             "integrity": "sha512-JSSBqZ6LvZxRdaNvezSRV7dIMK+hLc9lL1RTLCQDRZq2OllR6CDSh1OePsBa22jBWXmXwpL/z7anJsm3F59SMw=="
         },
         "@patternfly/react-table": {
-            "version": "4.29.37",
-            "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-4.29.37.tgz",
-            "integrity": "sha512-Z0OHRtjqQZjWEP0T6ECWIryGqmP8aJyN1gXZ+2eoNwkxp3jRjcFYhHEmOPmm8fVdH6zm7dmPLMlbh0mjZV2JRw==",
+            "version": "4.29.58",
+            "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-4.29.58.tgz",
+            "integrity": "sha512-0KaypqnO1baaS8ESpaMyPcGmOsAva7vO9GzBiiiKnYizfjsPPE58KryyiLu0fEXBT6ESzYYm8I6pZNzzlI50Ww==",
             "requires": {
-                "@patternfly/react-core": "^4.147.0",
-                "@patternfly/react-icons": "^4.11.8",
-                "@patternfly/react-styles": "^4.11.8",
-                "@patternfly/react-tokens": "^4.12.9",
+                "@patternfly/react-core": "^4.152.4",
+                "@patternfly/react-icons": "^4.11.14",
+                "@patternfly/react-styles": "^4.11.13",
+                "@patternfly/react-tokens": "^4.12.15",
                 "lodash": "^4.17.19",
-                "tslib": "1.13.0"
+                "tslib": "^2.0.0"
             },
             "dependencies": {
-                "tslib": {
-                    "version": "1.13.0",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-                    "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+                "@patternfly/react-core": {
+                    "version": "4.152.4",
+                    "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-4.152.4.tgz",
+                    "integrity": "sha512-saMnAoF3KnYB5k6K04Y6NtO61bXYl71yzGPYSrM/DjyWDlIGLqPPhMe4kbWafLTpSgJdkxPoODgVMDp2ZIJ0Jw==",
+                    "requires": {
+                        "@patternfly/react-icons": "^4.11.14",
+                        "@patternfly/react-styles": "^4.11.13",
+                        "@patternfly/react-tokens": "^4.12.15",
+                        "focus-trap": "6.2.2",
+                        "react-dropzone": "9.0.0",
+                        "tippy.js": "5.1.2",
+                        "tslib": "^2.0.0"
+                    }
+                },
+                "@patternfly/react-icons": {
+                    "version": "4.11.14",
+                    "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-4.11.14.tgz",
+                    "integrity": "sha512-SBwID1p+UaQ9BSmzIRFr+BJEhYgx1rWHlm2HIZzhoz7BG3Q7byaQ8ZNfZLm0D+ZGVJQ+fq0zUHGE1nzxDPFqNQ=="
+                },
+                "@patternfly/react-styles": {
+                    "version": "4.11.13",
+                    "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-4.11.13.tgz",
+                    "integrity": "sha512-svhnWIqZwJt1cOxwYjvz6lVYeL+c9D17xpKqlkJapXRxJL3ppTfIqwBrT3o9+02ElaXUTKt4xjMkSnEVjw4qxA=="
+                },
+                "@patternfly/react-tokens": {
+                    "version": "4.12.15",
+                    "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-4.12.15.tgz",
+                    "integrity": "sha512-lRW0qxGjuFEPMweBSQFHNRNoxavx5uR8b28f0lPN0Jlz4QsaCFVTmHM2XqflOHDpjE8SPJW/hJMSsyUrqnM5dw=="
                 }
             }
         },
@@ -3796,9 +3856,9 @@
             "integrity": "sha512-IwEphTD75liO8g+6taS+4oqz+nnroocNfWVHWz7j+N+ZO2vYrc6PV1q7GQhuahL0IOR7JccFTsFKQ/mb6iZWAg=="
         },
         "@react-hook/resize-observer": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/@react-hook/resize-observer/-/resize-observer-1.2.2.tgz",
-            "integrity": "sha512-F7ciucmLrF4vZM78sUpRquvMCSVJwu3ayxapsHKKzTOvixZtcwJZocDBOasQQIbd7DtXzD/sVEJCKJUC0X1MDA==",
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@react-hook/resize-observer/-/resize-observer-1.2.4.tgz",
+            "integrity": "sha512-ouYbtX9kcwG6a52cl2JiIm2e846bQ00RZ/3ATs7yDke/4Z/SG/+SWU8WTdCcBBS4R25nhBsbAjWdd85kHuhO6g==",
             "requires": {
                 "@juggle/resize-observer": "^3.3.1",
                 "@react-hook/latest": "^1.0.2",
@@ -7366,9 +7426,9 @@
             }
         },
         "csstype": {
-            "version": "2.6.17",
-            "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.17.tgz",
-            "integrity": "sha512-u1wmTI1jJGzCJzWndZo8mk4wnPTZd1eOIYTYvuEyOQGfmDl3TrabCCfKnOC86FZwW/9djqTl933UF/cS425i9A=="
+            "version": "2.6.18",
+            "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.18.tgz",
+            "integrity": "sha512-RSU6Hyeg14am3Ah4VZEmeX8H7kLwEEirXe6aU2IPfKNvhXwTflK5HQRDNI0ypQXoqmm+QPyG2IaPuQE5zMwSIQ=="
         },
         "cyclist": {
             "version": "1.0.1",
@@ -7850,9 +7910,9 @@
             },
             "dependencies": {
                 "csstype": {
-                    "version": "3.0.8",
-                    "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.8.tgz",
-                    "integrity": "sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw=="
+                    "version": "3.0.9",
+                    "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.9.tgz",
+                    "integrity": "sha512-rpw6JPxK6Rfg1zLOYCSwle2GFOOsnjmDYDaBwEcwoOg4qlsIVCN789VkBZDJAGi4T07gI4YSutR43t9Zz4Lzuw=="
                 }
             }
         },
@@ -12920,9 +12980,9 @@
             },
             "dependencies": {
                 "csstype": {
-                    "version": "3.0.8",
-                    "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.8.tgz",
-                    "integrity": "sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw=="
+                    "version": "3.0.9",
+                    "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.9.tgz",
+                    "integrity": "sha512-rpw6JPxK6Rfg1zLOYCSwle2GFOOsnjmDYDaBwEcwoOg4qlsIVCN789VkBZDJAGi4T07gI4YSutR43t9Zz4Lzuw=="
                 }
             }
         },
@@ -16454,11 +16514,11 @@
             "integrity": "sha512-X8jZHc7nCMjaCqoU+V2I0cOhNW+QMBwSUkeXnTi8IPe6zaRWfn60ZzvFDZqWPfmSJfjub7dDW1SP0jaHWLu/hg=="
         },
         "react-router": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.2.0.tgz",
-            "integrity": "sha512-smz1DUuFHRKdcJC0jobGo8cVbhO3x50tCL4icacOlcwDOEQPq4TMqwx3sY1TP+DvtTgz4nm3thuo7A+BK2U0Dw==",
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.2.1.tgz",
+            "integrity": "sha512-lIboRiOtDLFdg1VTemMwud9vRVuOCZmUIT/7lUoZiSpPODiiH1UQlfXy+vPLC/7IWdFYnhRwAyNqA/+I7wnvKQ==",
             "requires": {
-                "@babel/runtime": "^7.1.2",
+                "@babel/runtime": "^7.12.13",
                 "history": "^4.9.0",
                 "hoist-non-react-statics": "^3.1.0",
                 "loose-envify": "^1.3.1",
@@ -16471,15 +16531,15 @@
             }
         },
         "react-router-dom": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.2.0.tgz",
-            "integrity": "sha512-gxAmfylo2QUjcwxI63RhQ5G85Qqt4voZpUXSEqCwykV0baaOTQDR1f0PmY8AELqIyVc0NEZUj0Gov5lNGcXgsA==",
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.3.0.tgz",
+            "integrity": "sha512-ObVBLjUZsphUUMVycibxgMdh5jJ1e3o+KpAZBVeHcNQZ4W+uUGGWsokurzlF4YOldQYRQL4y6yFRWM4m3svmuQ==",
             "requires": {
-                "@babel/runtime": "^7.1.2",
+                "@babel/runtime": "^7.12.13",
                 "history": "^4.9.0",
                 "loose-envify": "^1.3.1",
                 "prop-types": "^15.6.2",
-                "react-router": "5.2.0",
+                "react-router": "5.2.1",
                 "tiny-invariant": "^1.0.2",
                 "tiny-warning": "^1.0.0"
             }
@@ -19484,66 +19544,66 @@
             "integrity": "sha512-/juG65kTL4Cy2su4P8HjtkTxk6VmJDiOPBufWniqQ6wknac6jNiXS9vU+hO3wgusiyqWlzTbVHi0dyJqRONg3w=="
         },
         "victory-area": {
-            "version": "35.11.0",
-            "resolved": "https://registry.npmjs.org/victory-area/-/victory-area-35.11.0.tgz",
-            "integrity": "sha512-FT1H0dhzxFpDrtBzZRe4DUVb+AAezCQIkL+8a46sJqeorQkpFGaSXjLly/fwmYgNctVzapiSLQLJtdXc2dI5zQ==",
+            "version": "35.11.4",
+            "resolved": "https://registry.npmjs.org/victory-area/-/victory-area-35.11.4.tgz",
+            "integrity": "sha512-i3rN4Jvn1uwA3YvCuv3EIPEcK2SWSOq3c+TvLvVj1BKFQug11C06UjyQje+3EEzffZ/EMkvGqj2+YudIjrGEzA==",
             "requires": {
                 "d3-shape": "^1.2.0",
                 "lodash": "^4.17.19",
                 "prop-types": "^15.5.8",
-                "victory-core": "^35.11.0"
+                "victory-core": "^35.11.4"
             }
         },
         "victory-axis": {
-            "version": "35.11.0",
-            "resolved": "https://registry.npmjs.org/victory-axis/-/victory-axis-35.11.0.tgz",
-            "integrity": "sha512-CwGuXM8D/N3LzNFf/8v2QbdmBNSBir7Rlp8ZAamN5H6VOpK7dyLvRb+F3jjLejkuyr+Ye9uwJkwTlPyuSJXM5Q==",
+            "version": "35.11.4",
+            "resolved": "https://registry.npmjs.org/victory-axis/-/victory-axis-35.11.4.tgz",
+            "integrity": "sha512-KmPXC/vgbiiWckhK0LruZvsFQqESg6BflhIqS/Xemc50ymWetqbT9VZhjPWbU0arOIP5E8xcFnGUimDN//Jffw==",
             "requires": {
                 "lodash": "^4.17.19",
                 "prop-types": "^15.5.8",
-                "victory-core": "^35.11.0"
+                "victory-core": "^35.11.4"
             }
         },
         "victory-bar": {
-            "version": "35.11.0",
-            "resolved": "https://registry.npmjs.org/victory-bar/-/victory-bar-35.11.0.tgz",
-            "integrity": "sha512-9hvuC+FO/EvU3dJeP8H5SkilVOpX8ctaNf0Nn6mOdS+cDWErQJ9cuHDaBehEl9uvevK2hQOYTt9g7JuvgRxBSA==",
+            "version": "35.11.4",
+            "resolved": "https://registry.npmjs.org/victory-bar/-/victory-bar-35.11.4.tgz",
+            "integrity": "sha512-EZC+6VGwHkIcOYEppVFBIC5JymYnfF+RLF+NM0Uys7q5+AwaLx36LS9a2xBUBYO/gx20Wd1HVH8kjSHzw1rTqQ==",
             "requires": {
                 "d3-shape": "^1.2.0",
                 "lodash": "^4.17.19",
                 "prop-types": "^15.5.8",
-                "victory-core": "^35.11.0"
+                "victory-core": "^35.11.4"
             }
         },
         "victory-brush-container": {
-            "version": "35.11.0",
-            "resolved": "https://registry.npmjs.org/victory-brush-container/-/victory-brush-container-35.11.0.tgz",
-            "integrity": "sha512-Z5bmCVhcWjH5P1aAEQKa2u1NiUZPunrmmSJ4u+npOVCpa03/sdEgnLGs89TVSRHZnFptWbhN3izrKhXkd5sMrA==",
+            "version": "35.11.4",
+            "resolved": "https://registry.npmjs.org/victory-brush-container/-/victory-brush-container-35.11.4.tgz",
+            "integrity": "sha512-KpFYU2LxKbLIjZDhXTdveok1SWLFlG5s2R214IRq+ukYRz21CoxlvZCWhFL60lSPilD+ZD1Udv3sK/RW9CFMxA==",
             "requires": {
                 "lodash": "^4.17.19",
                 "prop-types": "^15.5.8",
                 "react-fast-compare": "^2.0.0",
-                "victory-core": "^35.11.0"
+                "victory-core": "^35.11.4"
             }
         },
         "victory-chart": {
-            "version": "35.11.0",
-            "resolved": "https://registry.npmjs.org/victory-chart/-/victory-chart-35.11.0.tgz",
-            "integrity": "sha512-TBil5iyLd+ItAfM8vAf+557JipgkvHpyvLkJJOHsgSHT47F5djNLBAZcRuboKh15l/Y2+ARV+xRnDMAvxv6aWQ==",
+            "version": "35.11.4",
+            "resolved": "https://registry.npmjs.org/victory-chart/-/victory-chart-35.11.4.tgz",
+            "integrity": "sha512-oBTjx6ytp+/s6zswCuOUQotiISePQKuDUdOsjnbINBPSNvJuE2W9GXHD+B7ibDkCh4ZWXm8obHz7mnrRGbCGFQ==",
             "requires": {
                 "lodash": "^4.17.19",
                 "prop-types": "^15.5.8",
                 "react-fast-compare": "^2.0.0",
-                "victory-axis": "^35.11.0",
-                "victory-core": "^35.11.0",
-                "victory-polar-axis": "^35.11.0",
-                "victory-shared-events": "^35.11.0"
+                "victory-axis": "^35.11.4",
+                "victory-core": "^35.11.4",
+                "victory-polar-axis": "^35.11.4",
+                "victory-shared-events": "^35.11.4"
             }
         },
         "victory-core": {
-            "version": "35.11.0",
-            "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-35.11.0.tgz",
-            "integrity": "sha512-IU9ifAooK2dFQqVy2eMf6GQwE6e2MP+DrtxJCNZ27eLSRnUoXExH+toC+Ww/fguTmyyjTYvVH9mEnz0cswS1sA==",
+            "version": "35.11.4",
+            "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-35.11.4.tgz",
+            "integrity": "sha512-PuqrOIn/a6GQgsp/DKvACiJBAJo71P77jltn56mlDZjAAzz+58BL4E0hx7x908GdodLXo2n9gEeuDdjOAlOt0Q==",
             "requires": {
                 "d3-ease": "^1.0.0",
                 "d3-interpolate": "^1.1.1",
@@ -19556,158 +19616,158 @@
             }
         },
         "victory-create-container": {
-            "version": "35.11.0",
-            "resolved": "https://registry.npmjs.org/victory-create-container/-/victory-create-container-35.11.0.tgz",
-            "integrity": "sha512-cy9JN4wd0osRBvUIYdkdszi8zhGJBJhuIX5BkL9PKAjdsxviBs3GHuIAnuM/Q4Y9xNszSVDb/aRKK1Mei7Ur2A==",
+            "version": "35.11.4",
+            "resolved": "https://registry.npmjs.org/victory-create-container/-/victory-create-container-35.11.4.tgz",
+            "integrity": "sha512-baDLO4GSk/7eTVEYkhikwgwV5BtrSMuNPjKZBjZrIA3Ka9Fn5shklRG9PWg+26JIBFxqZdM6zOvpF7xhjxi37Q==",
             "requires": {
                 "lodash": "^4.17.19",
-                "victory-brush-container": "^35.11.0",
-                "victory-core": "^35.11.0",
-                "victory-cursor-container": "^35.11.0",
-                "victory-selection-container": "^35.11.0",
-                "victory-voronoi-container": "^35.11.0",
-                "victory-zoom-container": "^35.11.0"
+                "victory-brush-container": "^35.11.4",
+                "victory-core": "^35.11.4",
+                "victory-cursor-container": "^35.11.4",
+                "victory-selection-container": "^35.11.4",
+                "victory-voronoi-container": "^35.11.4",
+                "victory-zoom-container": "^35.11.4"
             }
         },
         "victory-cursor-container": {
-            "version": "35.11.0",
-            "resolved": "https://registry.npmjs.org/victory-cursor-container/-/victory-cursor-container-35.11.0.tgz",
-            "integrity": "sha512-SSWb8XH1hJDC1SbolcHWAJLKO8pHCCNqTYrQrQtkZhXEJU8+e02aluRmWCXY9gzSm1zUL/uz3XcTgtPBZnECsA==",
+            "version": "35.11.4",
+            "resolved": "https://registry.npmjs.org/victory-cursor-container/-/victory-cursor-container-35.11.4.tgz",
+            "integrity": "sha512-gs6bwRd/qbGTN78w2QgshIFxlyOsss5qWOMdCcY9i0Oi99l9OJ6UFQDBzSgKsgD53KGs7JxiKevmUqc3qSZZBg==",
             "requires": {
                 "lodash": "^4.17.19",
                 "prop-types": "^15.5.8",
-                "victory-core": "^35.11.0"
+                "victory-core": "^35.11.4"
             }
         },
         "victory-group": {
-            "version": "35.11.0",
-            "resolved": "https://registry.npmjs.org/victory-group/-/victory-group-35.11.0.tgz",
-            "integrity": "sha512-8HD3CGnUHj8jLVWbutBvh8rlLB+J94jx+ZBESDW7glRXNnp/kKOn9CeCgrxEiabZnd3s6kIYpeA0CLJJM+QbkQ==",
+            "version": "35.11.4",
+            "resolved": "https://registry.npmjs.org/victory-group/-/victory-group-35.11.4.tgz",
+            "integrity": "sha512-ceFBll9h1sPpdMjNcvdgEhnYELVHfx9ymmk8iMEjOKpxa4fVvapMhegPmL0/zTemJ/NCu71W2xIr0VqyqK0DaA==",
             "requires": {
                 "lodash": "^4.17.19",
                 "prop-types": "^15.5.8",
                 "react-fast-compare": "^2.0.0",
-                "victory-core": "^35.11.0",
-                "victory-shared-events": "^35.11.0"
+                "victory-core": "^35.11.4",
+                "victory-shared-events": "^35.11.4"
             }
         },
         "victory-legend": {
-            "version": "35.11.0",
-            "resolved": "https://registry.npmjs.org/victory-legend/-/victory-legend-35.11.0.tgz",
-            "integrity": "sha512-8eOHzB+K4WCXZJQiv3Kx5ihMa5+li+PjN4qw9f/oAtXG6zeTCK22WV5doll7clbAwwzljTDTrzjssuaXbq2EAg==",
+            "version": "35.11.4",
+            "resolved": "https://registry.npmjs.org/victory-legend/-/victory-legend-35.11.4.tgz",
+            "integrity": "sha512-JZzQARjxYorWlNf9RmZRPAzlgPjukiUV1aTBaeC8YA2S4PhP4PWhNwO/Pb3aCdkifpumpgsm3JULpJiCGOPdBQ==",
             "requires": {
                 "lodash": "^4.17.19",
                 "prop-types": "^15.5.8",
-                "victory-core": "^35.11.0"
+                "victory-core": "^35.11.4"
             }
         },
         "victory-line": {
-            "version": "35.11.0",
-            "resolved": "https://registry.npmjs.org/victory-line/-/victory-line-35.11.0.tgz",
-            "integrity": "sha512-A48QXeo3q0b5+WawR/Btbw08jm2RKdcD6uoTQKXTTSB/pf+TDh3RLqynwI21SmYA9a6HgO3ekqYReX40e4h9Gw==",
+            "version": "35.11.4",
+            "resolved": "https://registry.npmjs.org/victory-line/-/victory-line-35.11.4.tgz",
+            "integrity": "sha512-uKX6/1b1OmlqJZOsVDCCDlyc9QItgb39vRssTwP4CJX1NLU4Sfgq2i4VVUbHXCo/I2sMEczjf3cdnxdZtC6IFA==",
             "requires": {
                 "d3-shape": "^1.2.0",
                 "lodash": "^4.17.19",
                 "prop-types": "^15.5.8",
-                "victory-core": "^35.11.0"
+                "victory-core": "^35.11.4"
             }
         },
         "victory-pie": {
-            "version": "35.11.0",
-            "resolved": "https://registry.npmjs.org/victory-pie/-/victory-pie-35.11.0.tgz",
-            "integrity": "sha512-YPQ/ij0ENc5lV3jHabtGjz/GwG2ZFOZLZWbTGBEL/pvysIQF/TB6jyUsdnRxyJiOGHs63+L81Zcsc2NL92MGNg==",
+            "version": "35.11.4",
+            "resolved": "https://registry.npmjs.org/victory-pie/-/victory-pie-35.11.4.tgz",
+            "integrity": "sha512-EruxP3PIkrTPTzsC5YhiRKg2s+0UtaRU1ZHZUWK8qi+zlbMDFKYg2AlHqsEnctu5AOdOWLLiye6qUG3oxjiURg==",
             "requires": {
                 "d3-shape": "^1.0.0",
                 "lodash": "^4.17.19",
                 "prop-types": "^15.5.8",
-                "victory-core": "^35.11.0"
+                "victory-core": "^35.11.4"
             }
         },
         "victory-polar-axis": {
-            "version": "35.11.0",
-            "resolved": "https://registry.npmjs.org/victory-polar-axis/-/victory-polar-axis-35.11.0.tgz",
-            "integrity": "sha512-98iDKBOoTqQKmay2diC+HdM7hLknjNXJ1umxdBkNE4oD2lfF67eW7dNgEFxBvZDh8B8YVqq1asIlLmCvetAq2w==",
+            "version": "35.11.4",
+            "resolved": "https://registry.npmjs.org/victory-polar-axis/-/victory-polar-axis-35.11.4.tgz",
+            "integrity": "sha512-mnIRpfARn36TG6ZdCgKR+oWY+pIX6wLHYS0un5xM1TTObKk4IyAR3dnQhEp+3KM1SGoLg0mENFR1Ac8xrus6nQ==",
             "requires": {
                 "lodash": "^4.17.19",
                 "prop-types": "^15.5.8",
-                "victory-core": "^35.11.0"
+                "victory-core": "^35.11.4"
             }
         },
         "victory-scatter": {
-            "version": "35.11.0",
-            "resolved": "https://registry.npmjs.org/victory-scatter/-/victory-scatter-35.11.0.tgz",
-            "integrity": "sha512-oX2TgvlXpIkP4Bza+i7s0VziPhSdYi0+Q/bYYuYJdz+17jCseHBIjVww0jWC8wI0J5qVmD6eUA/u1W5Iz5Ml8A==",
+            "version": "35.11.4",
+            "resolved": "https://registry.npmjs.org/victory-scatter/-/victory-scatter-35.11.4.tgz",
+            "integrity": "sha512-8n9rmXmVju2SqA6Xd90rRTmboaU7WStOnj1QUg4q96DDiAVf6kGPdolzCwbUBbiECLyluGoFNJ043WLXztGpiA==",
             "requires": {
                 "lodash": "^4.17.19",
                 "prop-types": "^15.5.8",
-                "victory-core": "^35.11.0"
+                "victory-core": "^35.11.4"
             }
         },
         "victory-selection-container": {
-            "version": "35.11.0",
-            "resolved": "https://registry.npmjs.org/victory-selection-container/-/victory-selection-container-35.11.0.tgz",
-            "integrity": "sha512-ANxAAWwSrK4fbLcWKWrSkqHKDcrqSZicvy/AFIVqOIO/xzhZAJG8APIhMfJcpsxjjfq4qgeh/lcnSZmsqhslwA==",
+            "version": "35.11.4",
+            "resolved": "https://registry.npmjs.org/victory-selection-container/-/victory-selection-container-35.11.4.tgz",
+            "integrity": "sha512-Olxnjp9tvHUHeFr4zU/K1dzp0zbeqQRMr2Qqpr85Dd4pWV9bIReE/DanxGhjNg9s3KB5Vsn1GC46PXSTMM1XIQ==",
             "requires": {
                 "lodash": "^4.17.19",
                 "prop-types": "^15.5.8",
-                "victory-core": "^35.11.0"
+                "victory-core": "^35.11.4"
             }
         },
         "victory-shared-events": {
-            "version": "35.11.0",
-            "resolved": "https://registry.npmjs.org/victory-shared-events/-/victory-shared-events-35.11.0.tgz",
-            "integrity": "sha512-c+2scIqtvOOTd8UxGaX5AGLvXn+Cdv2zuSpyKK0Rczo0H2sFYeghBXfQSwYWgZucyTB45uJ6YXjJYmwxChjjZA==",
+            "version": "35.11.4",
+            "resolved": "https://registry.npmjs.org/victory-shared-events/-/victory-shared-events-35.11.4.tgz",
+            "integrity": "sha512-flvI27J9K+09BAbuVJf2w51D4OkXlDxE/5BlaHSKzM5jNDYsbcQ6djXa4pqa7NQtMGPOApTBkOSmVRyWRqVoYA==",
             "requires": {
                 "json-stringify-safe": "^5.0.1",
                 "lodash": "^4.17.19",
                 "prop-types": "^15.5.8",
                 "react-fast-compare": "^2.0.0",
-                "victory-core": "^35.11.0"
+                "victory-core": "^35.11.4"
             }
         },
         "victory-stack": {
-            "version": "35.11.0",
-            "resolved": "https://registry.npmjs.org/victory-stack/-/victory-stack-35.11.0.tgz",
-            "integrity": "sha512-QYr4XR2bywqg5m7rwyLBANrAXrH9D+Dk/qZrzIdPy+X+wzTnxLle0cPFh4AyDKx5UcX9V9ZjkkT2i5HM6+CObw==",
+            "version": "35.11.4",
+            "resolved": "https://registry.npmjs.org/victory-stack/-/victory-stack-35.11.4.tgz",
+            "integrity": "sha512-fNTY50fN+DCHcK/9AgMUEq0uJ8IXGnMlRtkSCzMB9ZpEzB7Edx3jLM2Gl970zOkwVaDYXTlikPd1dwf+h3m0dA==",
             "requires": {
                 "lodash": "^4.17.19",
                 "prop-types": "^15.5.8",
                 "react-fast-compare": "^2.0.0",
-                "victory-core": "^35.11.0",
-                "victory-shared-events": "^35.11.0"
+                "victory-core": "^35.11.4",
+                "victory-shared-events": "^35.11.4"
             }
         },
         "victory-tooltip": {
-            "version": "35.11.0",
-            "resolved": "https://registry.npmjs.org/victory-tooltip/-/victory-tooltip-35.11.0.tgz",
-            "integrity": "sha512-P7U44HsFtQ8/F2DEyGNXM+WdIm1uf/4qAzA8/B9rZi9x5f1coPk7GoBNScMfcKYMN0hw1XyPGy10npKb5PfPRw==",
+            "version": "35.11.4",
+            "resolved": "https://registry.npmjs.org/victory-tooltip/-/victory-tooltip-35.11.4.tgz",
+            "integrity": "sha512-B+UUqzryurtMghJGiE34tg5eI44vHxyOOcuPIM3IpJLujnNIJXVykBjgQZnFq1CT/63TtDCOlzPkOjSbecPtXQ==",
             "requires": {
                 "lodash": "^4.17.19",
                 "prop-types": "^15.5.8",
-                "victory-core": "^35.11.0"
+                "victory-core": "^35.11.4"
             }
         },
         "victory-voronoi-container": {
-            "version": "35.11.0",
-            "resolved": "https://registry.npmjs.org/victory-voronoi-container/-/victory-voronoi-container-35.11.0.tgz",
-            "integrity": "sha512-T2bvpNpkDXtSI+RMdRymvdmmIDH07udLt2LiICzVqVbj61Nr0BHh4KJlSMqQluao0Oo3cmiEabNiPv0DMfUGDQ==",
+            "version": "35.11.4",
+            "resolved": "https://registry.npmjs.org/victory-voronoi-container/-/victory-voronoi-container-35.11.4.tgz",
+            "integrity": "sha512-vmwHBm/+nZ9qdRcaNd7r08AVRkus/ER6UA4KAYWkKUe50ZT9NYjDxy0wW/Y7PHQldfL9q/VxAyIE/M6jSFWkEA==",
             "requires": {
                 "delaunay-find": "0.0.6",
                 "lodash": "^4.17.19",
                 "prop-types": "^15.5.8",
                 "react-fast-compare": "^2.0.0",
-                "victory-core": "^35.11.0",
-                "victory-tooltip": "^35.11.0"
+                "victory-core": "^35.11.4",
+                "victory-tooltip": "^35.11.4"
             }
         },
         "victory-zoom-container": {
-            "version": "35.11.0",
-            "resolved": "https://registry.npmjs.org/victory-zoom-container/-/victory-zoom-container-35.11.0.tgz",
-            "integrity": "sha512-NogTtrgK53CD8IFW1I3mLw/bbX9VzPmRUgW4we9oUV3tSYKkQjKkao0qOeZAarrWcSUeuKH0qGLghOMQEGvsyA==",
+            "version": "35.11.4",
+            "resolved": "https://registry.npmjs.org/victory-zoom-container/-/victory-zoom-container-35.11.4.tgz",
+            "integrity": "sha512-8D4hTdvGZqyZdgWjkz/pDRVy/kijWhptFbK0KWl5J1Tt4YuCGiRC9oxQOpEjlqr8TSyeVnpyuF4QuIp9YOIrAw==",
             "requires": {
                 "lodash": "^4.17.19",
                 "prop-types": "^15.5.8",
-                "victory-core": "^35.11.0"
+                "victory-core": "^35.11.4"
             }
         },
         "vm-browserify": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,7 +21,7 @@
     },
     "dependencies": {
         "@apollo/client": "^3.4.5",
-        "@open-cluster-management/ui-components": "^1.4.0",
+        "@open-cluster-management/ui-components": "^1.9.0",
         "@patternfly/react-core": "^4.147.0",
         "@types/node": "^16.4.13",
         "@types/react": "^17.0.16",
@@ -42,7 +42,7 @@
         "react-dom": "^17.0.2",
         "react-i18next": "^11.11.4",
         "react-monaco-editor": "^0.44.0",
-        "react-router-dom": "^5.2.0",
+        "react-router-dom": "^5.3.0",
         "react-scripts": "^4.0.3",
         "recoil": "^0.4.0",
         "typescript": "^4.3.5"

--- a/frontend/src/routes/Overview/OverviewPage.test.tsx
+++ b/frontend/src/routes/Overview/OverviewPage.test.tsx
@@ -22,6 +22,8 @@ it('should responsed with correct value for mapProviderFromLabel function', () =
     expect(mapProviderFromLabel('IBMZPlatform')).toEqual('ibmz')
     expect(mapProviderFromLabel('RedHat')).toEqual('rhocm')
     expect(mapProviderFromLabel('VMware')).toEqual('vmw')
+    expect(mapProviderFromLabel('VSphere')).toEqual('vmw')
+    expect(mapProviderFromLabel('vSphere')).toEqual('vmw')
     expect(mapProviderFromLabel('other')).toEqual('other')
 })
 

--- a/frontend/src/routes/Overview/OverviewPage.tsx
+++ b/frontend/src/routes/Overview/OverviewPage.tsx
@@ -379,9 +379,12 @@ export default function OverviewPage() {
 
     const { kubernetesTypes, regions, ready, offline, providers } = summaryData
     const provider = providers.find((p: any) => p.provider === selectedCloud)
-    const cloudLabelFilter: string = selectedCloud === ''
-        ? ''
-        : `%20label%3a${Array.from(provider.cloudLabels).map(n => `cloud=${n}`).join(',')}`
+    const cloudLabelFilter: string =
+        selectedCloud === ''
+            ? ''
+            : `%20label%3a${Array.from(provider.cloudLabels)
+                  .map((n) => `cloud=${n}`)
+                  .join(',')}`
     function buildSummaryLinks(kind: string, localCluster?: boolean) {
         const localClusterFilter: string = localCluster === true ? `%20cluster%3Alocal-cluster` : ''
         return selectedCloud === ''

--- a/frontend/src/routes/SearchPage/components/SearchResults.tsx
+++ b/frontend/src/routes/SearchPage/components/SearchResults.tsx
@@ -110,14 +110,12 @@ function RenderRelatedTables(
                                 searchDefinitions['genericresource'].columns
                             )}
                             keyFn={(item: any) => item._uid.toString()}
-                            tableActions={[]}
                             rowActions={GetRowActions(
                                 kind,
                                 t('search.results.delete.resource', { resourceKind: kind }),
                                 currentQuery,
                                 setDeleteResource
                             )}
-                            bulkActions={[]}
                         />
                     </AcmExpandableSection>
                 </AcmPageCard>
@@ -267,14 +265,12 @@ function RenderSearchTables(
                                     searchDefinitions['genericresource'].columns
                                 )}
                                 keyFn={(item: any) => item._uid.toString()}
-                                tableActions={[]}
                                 rowActions={GetRowActions(
                                     kind,
                                     t('search.results.delete.resource', { resourceKind: kind }),
                                     currentQuery,
                                     setDeleteResource
                                 )}
-                                bulkActions={[]}
                             />
                         </AcmExpandableSection>
                     </AcmPageCard>


### PR DESCRIPTION
**Related Issue:**  open-cluster-management/backlog#16135
https://bugzilla.redhat.com/show_bug.cgi?id=2004188

### Description of changes
- VMware / vSphere show as VMware vSphere on the Overview regardless of case
- Grouping is fixed so different labels can coexist (for example, different cases, miscellaneous "Other" labels)
- Search for all labels in the group (eg. `search?filters={"textsearch":"kind%3Acluster%20label%3Acloud%3DVSphere%2Ccloud%3DvSphere%2Ccloud%3DVMware"`}... this does not work for the Other category which includes unlabelled clusters - we still get only `cloud=Other` clusters in that case)
- [release-2.4 only] Update ui-components so that Provider cards show plural "Clusters" when count is not 1.

![image](https://user-images.githubusercontent.com/42188127/133498688-cd818d5c-8663-4f11-b731-03bc89e1199b.png)
![image](https://user-images.githubusercontent.com/42188127/133498710-1c710f83-9a8a-43d8-9e58-cd3bf166aafd.png)
![image](https://user-images.githubusercontent.com/42188127/133498792-20823a85-2729-4919-a48d-a0ca628bb128.png)
